### PR TITLE
Added throttle support for c172p's non-standard engine node.

### DIFF
--- a/linux_xpad/x360.nas
+++ b/linux_xpad/x360.nas
@@ -21,6 +21,15 @@ var _updateThrottle = func () {
                 var delta = -math.pow(metrics.throttle_axis, 3) *
                                 getprop("/sim/time/delta-realtime-sec") * THROTTLE_FACTOR;
                 var thr = {};
+				
+				# c172p uses controls/engines/current-engine/throttle
+				var old_value = getprop("/controls/engines/current-engine/throttle");
+				if(old_value != nil) {
+					var new_value = delta + old_value;
+					setprop("/controls/engines/current-engine/throttle", new_value);
+				}
+				# end c172p specific block
+				
                 foreach (var eng; controls.engines) {
                         if (eng.selected.getBoolValue()) {
                                 thr = eng.controls.getNode("throttle", 1);

--- a/windows/x360.nas
+++ b/windows/x360.nas
@@ -21,9 +21,18 @@ var _updateThrottle = func () {
                 var delta = -math.pow(metrics.throttle_axis, 3) *
                                 getprop("/sim/time/delta-realtime-sec") * THROTTLE_FACTOR;
                 var thr = {};
+				
+				# c172p uses controls/engines/current-engine/throttle
+				var old_value = getprop("/controls/engines/current-engine/throttle");
+				if(old_value != nil) {
+					var new_value = delta + old_value;
+					setprop("/controls/engines/current-engine/throttle", new_value);
+				}
+				# end c172p specific block
+				
                 foreach (var eng; controls.engines) {
                         if (eng.selected.getBoolValue()) {
-                                thr = eng.controls.getNode("throttle", 1);
+                                thr = eng.controls.getNode("throttle");
                                 thr.setDoubleValue(thr.getValue() + delta);
                         }
                 }


### PR DESCRIPTION
Right-thumbstick throttle control will now work for c172p's throttle.